### PR TITLE
Fix sim torque telemetry UX and formalize multi-instance sync tracking

### DIFF
--- a/prism_twin/docs/firmware-faithful-twin-spec.md
+++ b/prism_twin/docs/firmware-faithful-twin-spec.md
@@ -508,6 +508,27 @@ Required capabilities for composed scenes:
 Non-goal clarification:
 - PRISM twin does not own robot planning/control; it exposes a stable PRISM interaction interface that a robot/scene controller can consume.
 
+### 23.1 Current Viewer Behavior and Blocker Assessment
+
+Current behavior (accepted for now):
+- In standalone multi-instance runtime mode, each PRISM instance currently owns its own MuJoCo `MjModel`/`MjData` pair.
+- Native `--with-viewer` mode renders one selected instance at a time.
+- Switching visible instance is implemented by relaunching the native viewer against the selected instance (via API/UI routing).
+
+Blocker assessment:
+- This is not a fundamental MuJoCo limitation.
+- The current constraint is architectural: instances are hosted as separate model/data worlds, so one passive viewer cannot display both simultaneously.
+
+Required architecture for true concurrent same-viewer instances (and robot + PRISM scenes):
+1. Use one composed MuJoCo world containing all PRISM mounts/instances and robot/environment bodies.
+2. Replace per-instance model ownership with per-instance index maps into the shared model (`qpos`, `qvel`, actuator IDs, joint IDs).
+3. Keep API/session semantics instance-scoped while execution runs on one shared simulation step.
+4. Preserve namespace guarantees for all PRISM entities to avoid collisions in composed scenes.
+
+Decision note:
+- Temporary single-viewer switching is acceptable for current milestone UX.
+- Long-term target remains concurrent visibility and interaction for multiple PRISMs in the same viewer and same world as the robot.
+
 ## 21) Requirement Traceability Matrix
 
 | Requirement | Primary Module(s) | Validation / Check |

--- a/prism_twin/docs/firmware-faithful-twin-spec.md
+++ b/prism_twin/docs/firmware-faithful-twin-spec.md
@@ -315,21 +315,32 @@ Execution order per tick (mandatory):
 ## 16) Architecture Diagram (Mermaid)
 
 ```mermaid
-flowchart TD
-    UI[UI] --> API[REST API]
-    CLIENT[Client] --> API
-    API --> LOOP[Loop]
-    LOOP --> EST[State Estimator]
-    EST --> CTRL[Haptic Controller]
-    CTRL --> ESC[ESC Model]
-    ESC --> PLANT[MuJoCo Plant]
-    PLANT --> EST
-    LOOP --> TEL[Telemetry]
-    TEL --> API
-    PRESETS[Preset Source] --> CTRL
-    THRESH[Thresholds] --> VALID[Validation]
-    LOOP --> VALID
-    TEL --> VALID
+flowchart LR
+  OP[Operator / Client] --> API[Unified REST API]
+  SIMUI[Sim Helper UI] --> API
+  HWUI[STM32 Hardware HTML UI] --> HW[PRISM Hardware Controller]
+
+  API --> ROUTER[Target Router]
+  ROUTER --> SIMAD[Sim Target Adapter]
+  ROUTER --> REALAD[Real Target Adapter]
+
+  SIMAD --> LOOP[Sim Runtime Loop]
+  LOOP --> EST[State Estimator]
+  EST --> CTRL[Firmware-Faithful Controller]
+  CTRL --> ESC[Actuator/ESC Emulation]
+  ESC --> PLANT[MuJoCo Plant]
+  PLANT --> EST
+
+  REALAD --> HW
+
+  LOOP --> TELSIM[Telemetry Normalizer]
+  HW --> TELREAL[Telemetry Normalizer]
+  TELSIM --> API
+  TELREAL --> API
+
+  PRESETS[Preset Source] --> CTRL
+  THRESH[Validation Thresholds] --> VALID[Validation Harness]
+  LOOP --> VALID
 ```
 
 ## 17) Implementation Mapping (Current Workspace)
@@ -458,6 +469,44 @@ To realize the above strategy, the next milestone SHALL deliver:
 3. Handle catalog file and loader with defaults (inches, `Y_to_Z`, `z_offset_mm=105`).
 4. Sim helper UI widget for instance + handle selection.
 5. Viewer interaction mode for click-drag shaft rotation with telemetry.
+
+## 22) API + UI Deployment Decision (Sim vs Real)
+
+Decision:
+- The project SHALL use one logical REST API contract with target routing (`sim` / `real`).
+- UI deployment SHALL remain split by runtime environment:
+  - Real hardware UI remains the STM32-hosted HTML page for hardware operation.
+  - Simulation uses an independent helper UI hosted by the twin runtime.
+
+Rationale:
+- Simulation must run without STM32 dependency.
+- Sim-specific controls (instance spawn, manual position slider, scene/debug controls) are not applicable to real hardware.
+- This preserves a light-touch approach on real-hardware code and deployment while converging API semantics.
+
+Contract rules:
+- API responses always include `target_kind` and `target_id`.
+- Sim-only controls must be explicitly rejected or hidden for `target_kind=real`.
+- Shared controls (status/config/preset intent) use the same API schema across targets.
+
+## 23) Large-Scene MuJoCo Integration Model
+
+Goal:
+- Avoid painting the twin into a corner; PRISM must be embeddable in larger scenes (e.g., robot manipulator interacting with PRISM).
+
+Functional model:
+1. PRISM remains a reusable scene component rooted at `prism_mount`.
+2. Larger scene owns global `world` and additional bodies (robot arm, fixtures, tools).
+3. Integration places PRISM by setting `prism_mount` pose only; internal PRISM frames/joint semantics remain unchanged.
+4. Sim Target Adapter binds controller/runtime to the PRISM joint/actuator names in the composed MuJoCo model.
+5. Telemetry/control remain instance-scoped so multiple PRISM devices can coexist in one scene.
+
+Required capabilities for composed scenes:
+- Attach-to-existing-model mode (controller/runtime can operate on a named PRISM instance inside a preloaded scene).
+- Stable namespace convention for PRISM entities to avoid collisions.
+- No assumptions that PRISM is the only articulated object in simulation.
+
+Non-goal clarification:
+- PRISM twin does not own robot planning/control; it exposes a stable PRISM interaction interface that a robot/scene controller can consume.
 
 ## 21) Requirement Traceability Matrix
 

--- a/prism_twin/docs/github-issue-multi-instance-sync.md
+++ b/prism_twin/docs/github-issue-multi-instance-sync.md
@@ -1,0 +1,55 @@
+# Issue Draft: Align multi-instance semantics across firmware, sim, UI, and CLI
+
+## Title
+Synchronize multi-instance PRISM architecture across hardware API mechanics and UI/CLI contracts
+
+## Summary
+We need one explicit architecture for how multiple PRISM instances are addressed and managed across:
+- Real hardware runtime/API behavior (mechanics + endpoint semantics)
+- Simulation runtime/API behavior
+- UI behavior (hardware HTML and sim helper)
+- CLI behavior
+
+Current sim runtime supports instance-scoped operations and viewer target switching, while real-target routing is present but adapter wiring remains staged. We should prevent divergence now by defining one canonical contract.
+
+## Problem
+Without a shared spec and implementation plan, we risk:
+- API drift between `sim` and `real` targets
+- inconsistent UX between hardware UI and sim UI for multi-instance targeting
+- mismatched CLI affordances vs API routing (`target_kind`, `target_id`, `instance_id`)
+- difficult migration when moving to composed single-world multi-PRISM + robot scenes
+
+## Proposed outcomes
+1. Define canonical multi-instance target model:
+   - `target_kind` (`sim|real`)
+   - `target_id` (hardware id or instance id)
+   - `instance_id` resolution rules
+2. Define parity matrix for endpoints:
+   - shared endpoints and guaranteed semantics
+   - sim-only and real-only endpoint classes
+   - explicit capability negotiation behavior
+3. Define UI/CLI interaction contract:
+   - target selection UX for hardware UI, sim UI, and CLI
+   - failure semantics for unavailable targets/capabilities
+4. Define migration path for composed scenes:
+   - from per-instance model/data worlds to shared composed-world index mapping
+
+## Scope
+- In scope: API/contract design, UI/CLI contract, integration plan and acceptance criteria
+- Out of scope: full real adapter implementation details for all hardware capabilities
+
+## Acceptance criteria
+- Written contract doc for multi-instance routing used by firmware + twin + CLI clients
+- Endpoint parity matrix approved and published
+- UI contract approved (shared vs sim-only vs real-only behavior)
+- CLI target selection semantics approved and tested against API
+- Implementation milestones and ownership assigned
+
+## Suggested labels
+- architecture
+- api
+- simulation
+- firmware
+- ui
+- cli
+- multi-instance

--- a/prism_twin/docs/implementation-plan.md
+++ b/prism_twin/docs/implementation-plan.md
@@ -57,14 +57,32 @@
 - [ ] J2. Verify API and telemetry isolation by `instance_id`.
 - [ ] J3. Add regression tests for handle swap correctness and persistence.
 
+## Phase K — Unified API / Multi-Target Routing
+- [x] K1. Add explicit `target_kind`/`target_id` metadata in status/config responses.
+- [ ] K2. Introduce formal Target Router abstraction (`sim` and `real` adapters behind one API surface).
+- [ ] K3. Enforce sim-only endpoint gating (reject or no-op on `target_kind=real`).
+- [ ] K4. Add cross-target contract tests to confirm schema parity for shared endpoints.
+
+## Phase L — UI Strategy and Deployment Split
+- [x] L1. Decide deployment split: STM32-hosted hardware UI remains real-only; independent sim helper UI for simulation.
+- [ ] L2. Define shared control surface vs sim-only control surface.
+- [ ] L3. Update helper UI to clearly label sim-only controls and target context.
+- [ ] L4. Document operator workflow for choosing real vs sim UI paths.
+
+## Phase M — Composed MuJoCo Scene Integration
+- [ ] M1. Define attach-to-existing-scene mode (operate on PRISM instance inside larger MuJoCo model).
+- [ ] M2. Add namespace contract for PRISM entities in multi-articulation scenes.
+- [ ] M3. Validate PRISM + robot-arm co-simulation baseline without changing PRISM controller semantics.
+- [ ] M4. Add regression scenario for PRISM interaction in a composed scene.
+
 ## Immediate Work Started (Now)
 1. Implement Phase B (preset extraction + loader parity). ✅
 2. Implement Phase E baseline telemetry parity. ✅
 3. Scaffold deterministic runner hook (Phase C5). ✅
 
 ## Next Actions (Priority Order)
-1. Build `instance_id` runtime/API routing (Phase G1-G4).
-2. Add handle catalog + loader + swap path (Phase H1-H3).
-3. Implement minimal sim helper UI for target and handle selection (Phase I1-I2).
-4. Add click-drag interaction with live telemetry (Phase I3-I4).
-5. Extend validation to multi-instance isolation checks (Phase J1-J2).
+1. Land persistence hardening and runtime diagnostics acceptance for reconnect safety.
+2. Implement Phase K2-K4 (formal target router + target-gating + contract tests).
+3. Execute Phase L2-L4 (clear split between shared vs sim-only UI controls).
+4. Begin Phase M1-M2 to guarantee compatibility with larger composed MuJoCo scenes.
+5. Defer containerization for viewer path; containerize headless runtime only after K/L contracts stabilize.

--- a/prism_twin/docs/runtime-session-contract.md
+++ b/prism_twin/docs/runtime-session-contract.md
@@ -27,6 +27,11 @@ Returns expanded runtime diagnostics:
 - `instances`: current managed instances.
 - `sessions`: active sessions with `created_at_s` and `last_seen_s`.
 
+### `GET /api/v1/targets/capabilities`
+Returns target capability metadata for client/UI negotiation:
+- `targets.sim.configured` and supported shared/sim-only endpoint groups.
+- `targets.real.configured` status for real-target adapter readiness.
+
 ## Session Binding Endpoint
 
 ### `POST /api/v1/session/bind`
@@ -48,6 +53,8 @@ Response fields:
   2) bound `session_id` (query/body),
   3) fallback default `prism_01`.
 - This supports reconnect-safe clients that only retain a `session_id`.
+- If `target_kind=real` is requested before real adapter wiring is configured,
+  shared target endpoints return HTTP `501` with explicit `not configured` error.
 
 ## Session Lifecycle Policies
 - `--session-ttl-s` (default `900`): session expires after inactivity.

--- a/prism_twin/docs/runtime-session-contract.md
+++ b/prism_twin/docs/runtime-session-contract.md
@@ -32,6 +32,13 @@ Returns target capability metadata for client/UI negotiation:
 - `targets.sim.configured` and supported shared/sim-only endpoint groups.
 - `targets.real.configured` status for real-target adapter readiness.
 
+Helper UI behavior contract:
+- `simulation/sim_helper_ui.html` reads capabilities at startup before enabling controls.
+- Sim-only controls (`instances`, `control`, `handle_select`, `preset_select`, `interaction_set_position`) are hidden unless `target_kind=sim` and `targets.sim.configured=true`.
+- When opened with `?target_kind=real&target_id=<id>`, the helper UI enters telemetry-only mode.
+- If `targets.real.configured=false`, the helper UI skips real-target status polling and renders an explicit unavailable state instead of issuing invalid requests.
+- In `--with-viewer` mode, the native MuJoCo viewer renders the configured viewer instance only; additional created instances are active in API/runtime state but are not simultaneously shown in the same viewer window.
+
 ## Session Binding Endpoint
 
 ### `POST /api/v1/session/bind`
@@ -46,6 +53,13 @@ Response fields:
 - `created_session`: whether session record was newly created.
 - `session`: `{ session_id, instance_id, target_kind, target_id }`.
 - `session_policy`: current TTL/max settings.
+
+### `POST /api/v1/viewer/select`
+Optional viewer-instance routing endpoint (only when server started with `--with-viewer`):
+- Body fields: `instance_id` (or equivalent sim target selectors).
+- Behavior: requests native MuJoCo viewer to relaunch against the specified sim instance.
+- Success: `200` with `viewer_instance`.
+- If viewer mode is disabled: `409` with `viewer_not_enabled`.
 
 ## Routing Semantics
 - If `instance_id` is not provided on requests that need targeting, server resolves by:

--- a/prism_twin/docs/runtime-session-contract.md
+++ b/prism_twin/docs/runtime-session-contract.md
@@ -1,0 +1,61 @@
+# Runtime Session Contract (Persistence Phase 2)
+
+This document defines runtime/session behavior for the PRISM twin REST server.
+
+## Scope
+- Applies to `prism_twin/simulation/twin_rest_server.py`.
+- Covers reconnect-safe session binding and runtime diagnostics.
+- Keeps behavior isolated to `prism_twin` (no real-hardware runtime changes).
+
+## Runtime Endpoints
+
+### `GET /api/v1/health`
+Returns liveness/readiness summary:
+- `status`: `ok` when handler is alive.
+- `uptime_s`: process uptime.
+- `running`: whether control loop is active.
+- `instance_count`: number of managed instances.
+- `session_count`: number of currently active sessions (after prune).
+
+### `GET /api/v1/runtime`
+Returns expanded runtime diagnostics:
+- `status`, `uptime_s`, `requests`.
+- `session_policy`:
+  - `ttl_s`: inactivity expiration threshold.
+  - `max_count`: max active sessions before eviction.
+- `manager`: control-loop and instance summary.
+- `instances`: current managed instances.
+- `sessions`: active sessions with `created_at_s` and `last_seen_s`.
+
+## Session Binding Endpoint
+
+### `POST /api/v1/session/bind`
+Body fields:
+- `session_id` (optional): if absent, server generates UUID.
+- `instance_id` (optional): defaults to resolution behavior; explicit is recommended.
+- `create_if_missing` (optional, default `true`): create instance idempotently.
+- `client_id` (optional): caller identity for diagnostics.
+
+Response fields:
+- `created_instance`: whether instance was created by this call.
+- `created_session`: whether session record was newly created.
+- `session`: `{ session_id, instance_id, target_kind, target_id }`.
+- `session_policy`: current TTL/max settings.
+
+## Routing Semantics
+- If `instance_id` is not provided on requests that need targeting, server resolves by:
+  1) explicit `instance_id` query/body,
+  2) bound `session_id` (query/body),
+  3) fallback default `prism_01`.
+- This supports reconnect-safe clients that only retain a `session_id`.
+
+## Session Lifecycle Policies
+- `--session-ttl-s` (default `900`): session expires after inactivity.
+- `--session-max-count` (default `64`): server evicts least-recently-seen sessions when over limit.
+- Pruning is applied on request handling.
+
+## Persistence Acceptance Criteria (Phase 2)
+1. Repeated `POST /api/v1/instances` for same ID is idempotent (`created=false` on subsequent calls).
+2. Session bind can create/reuse instance and session deterministically.
+3. `status` resolution via `session_id` returns telemetry for bound target instance.
+4. Session expiration/eviction policy is observable via `/health` and `/runtime`.

--- a/prism_twin/docs/safe-convergence-checklist.md
+++ b/prism_twin/docs/safe-convergence-checklist.md
@@ -16,15 +16,15 @@ Goal: converge toward one API surface and one control-core contract with multipl
 
 ## C) Convergence Architecture Checklist
 - [ ] C1. Define `TargetAdapter` contract (`sim`, `real`).
-- [ ] C2. Define `TargetRouter` semantics (`target_kind`, `target_id`, session binding).
+- [x] C2. Define `TargetRouter` semantics (`target_kind`, `target_id`, session binding).
 - [ ] C3. Keep telemetry contract shape identical across targets.
-- [ ] C4. Add reconnect-safe, idempotent runtime/session semantics.
+- [x] C4. Add reconnect-safe, idempotent runtime/session semantics.
 
 ## D) Persistence Implementation Readiness
 - [x] D1. Branch selected: `feature/prism-twin-persistent-server`.
 - [x] D2. Branch synchronized with federated base.
-- [ ] D3. Runtime diagnostics endpoints planned (`/api/v1/health`, `/api/v1/runtime`).
-- [ ] D4. Persistence acceptance criteria documented.
+- [x] D3. Runtime diagnostics endpoints planned (`/api/v1/health`, `/api/v1/runtime`).
+- [x] D4. Persistence acceptance criteria documented.
 
 ## E) Execution Log
 - Date: 2026-03-05

--- a/prism_twin/docs/safe-convergence-checklist.md
+++ b/prism_twin/docs/safe-convergence-checklist.md
@@ -1,0 +1,44 @@
+# Safe Convergence Checklist (Sim + Real API Strategy)
+
+Goal: converge toward one API surface and one control-core contract with multiple execution targets (`sim`, `real`) while keeping a light touch on real-hardware code.
+
+## A) Merge Confidence Gate (Federated Base)
+- [x] A1. Confirm base federation branch exists and is up to date with origin.
+- [x] A2. Confirm change scope is isolated (prefer `prism_twin/` + minimal repo plumbing only).
+- [x] A3. Confirm no functional changes to current real-hardware runtime path.
+- [x] A4. Run twin sanity checks and record pass/fail.
+
+## B) Real-Hardware Light-Touch Guardrails
+- [x] B1. Any convergence code lands under `prism_twin/` first.
+- [ ] B2. No firmware/control-loop behavior changes without explicit parity test plan.
+- [ ] B3. Real-target integration introduced behind explicit target adapter boundary.
+- [ ] B4. Keep all new behavior opt-in until validated.
+
+## C) Convergence Architecture Checklist
+- [ ] C1. Define `TargetAdapter` contract (`sim`, `real`).
+- [ ] C2. Define `TargetRouter` semantics (`target_kind`, `target_id`, session binding).
+- [ ] C3. Keep telemetry contract shape identical across targets.
+- [ ] C4. Add reconnect-safe, idempotent runtime/session semantics.
+
+## D) Persistence Implementation Readiness
+- [x] D1. Branch selected: `feature/prism-twin-persistent-server`.
+- [x] D2. Branch synchronized with federated base.
+- [ ] D3. Runtime diagnostics endpoints planned (`/api/v1/health`, `/api/v1/runtime`).
+- [ ] D4. Persistence acceptance criteria documented.
+
+## E) Execution Log
+- Date: 2026-03-05
+- Branch: `feature/prism-twin-persistent-server`
+- Commands run:
+	- `git diff --name-only origin/main...origin/feature/prism-twin-federated-setup`
+	- `uv run --python 3.11 --project PRISM_source/prism_twin python scripts/check_telemetry_schema.py`
+	- `uv run --python 3.11 --project PRISM_source/prism_twin python scripts/validate_handle_catalog.py`
+	- `uv run --python 3.11 --project PRISM_source/prism_twin python scripts/check_instance_isolation.py`
+- Results:
+	- Scope gate passed: only `prism_twin/*` plus `.gitignore` differ from `origin/main`.
+	- Telemetry schema check: PASSED.
+	- Handle catalog validation: PASSED.
+	- Instance isolation check: PASSED.
+	- Note: initial runs failed under CPython 3.14 (`mujoco` build); rerun with Python 3.11 succeeded.
+- Decision:
+	- Proceed with persistence implementation on `feature/prism-twin-persistent-server` using light-touch guardrails (real-hardware path unchanged).

--- a/prism_twin/simulation/instance_manager.py
+++ b/prism_twin/simulation/instance_manager.py
@@ -42,8 +42,29 @@ class PrismRuntimeManager:
         self._instances: dict[str, PrismInstance] = {}
         self._running = False
         self._loop_thread: threading.Thread | None = None
+        self._created_at_s = time.time()
 
         self.handle_catalog, self.default_handle_id = load_handle_catalog()
+
+    def create_or_get_instance(
+        self,
+        instance_id: str,
+        handle_id: str | None = None,
+        preset: str | None = None,
+        prism_mount_pos: tuple[float, float, float] | None = None,
+        prism_mount_quat: tuple[float, float, float, float] | None = None,
+    ) -> tuple[PrismInstance, bool]:
+        with self._lock:
+            if instance_id in self._instances:
+                return self._instances[instance_id], False
+            created = self.create_instance(
+                instance_id=instance_id,
+                handle_id=handle_id,
+                preset=preset,
+                prism_mount_pos=prism_mount_pos,
+                prism_mount_quat=prism_mount_quat,
+            )
+            return created, True
 
     def _model_path_for_instance(self, instance_id: str) -> Path:
         return self.generated_models_dir / f"prism_device_{instance_id}.xml"
@@ -291,3 +312,17 @@ class PrismRuntimeManager:
             self._loop_thread = None
         if thread is not None:
             thread.join(timeout=1.0)
+
+    def is_running(self) -> bool:
+        with self._lock:
+            return bool(self._running)
+
+    def runtime_summary(self) -> dict:
+        with self._lock:
+            return {
+                "running": bool(self._running),
+                "control_hz": float(self.control_hz),
+                "uptime_s": float(time.time() - self._created_at_s),
+                "instance_count": len(self._instances),
+                "instance_ids": sorted(self._instances.keys()),
+            }

--- a/prism_twin/simulation/instance_manager.py
+++ b/prism_twin/simulation/instance_manager.py
@@ -32,9 +32,15 @@ class PrismRuntimeManager:
         "prism_02": ((0.0, 0.0, 0.3), (0.70710678, 0.70710678, 0.0, 0.0)),
     }
 
-    def __init__(self, root_dir: Path | None = None, control_hz: float = 1000.0):
+    def __init__(
+        self,
+        root_dir: Path | None = None,
+        control_hz: float = 1000.0,
+        composed_model_path: Path | None = None,
+    ):
         self.root_dir = root_dir or Path(__file__).resolve().parents[1]
         self.base_model_path = self.root_dir / "models" / "prism_device.xml"
+        self.composed_model_path = Path(composed_model_path).resolve() if composed_model_path else None
         self.generated_models_dir = self.root_dir / "models"
         self.control_hz = float(control_hz)
         self.default_preset = "HEAVY"
@@ -69,6 +75,9 @@ class PrismRuntimeManager:
     def _model_path_for_instance(self, instance_id: str) -> Path:
         return self.generated_models_dir / f"prism_device_{instance_id}.xml"
 
+    def is_composed_mode(self) -> bool:
+        return self.composed_model_path is not None
+
     def _create_sim(self, instance_id: str, model_path: Path, preset: str) -> PrismSim:
         return PrismSim(
             str(model_path),
@@ -93,13 +102,17 @@ class PrismRuntimeManager:
         with self._lock:
             if instance_id in self._instances:
                 raise ValueError(f"Instance already exists: {instance_id}")
-            if handle_id not in self.handle_catalog:
+            if self.is_composed_mode() and instance_id != "prism_01":
+                raise ValueError("Composed-scene mode currently supports only instance_id='prism_01'")
+
+            if not self.is_composed_mode() and handle_id not in self.handle_catalog:
                 raise ValueError(f"Unknown handle_id: {handle_id}")
 
-            handle = self.handle_catalog[handle_id]
-            errors = validate_handle_assets(handle)
-            if errors:
-                raise ValueError(";".join(errors))
+            if not self.is_composed_mode():
+                handle = self.handle_catalog[handle_id]
+                errors = validate_handle_assets(handle)
+                if errors:
+                    raise ValueError(";".join(errors))
 
             default_pos, default_quat = self.DEFAULT_INSTANCE_POSES.get(
                 instance_id,
@@ -108,14 +121,19 @@ class PrismRuntimeManager:
             prism_mount_pos = prism_mount_pos or default_pos
             prism_mount_quat = prism_mount_quat or default_quat
 
-            model_path = self._model_path_for_instance(instance_id)
-            build_model_for_handle(
-                self.base_model_path,
-                model_path,
-                handle,
-                prism_mount_pos=prism_mount_pos,
-                prism_mount_quat=prism_mount_quat,
-            )
+            if self.is_composed_mode():
+                model_path = self.composed_model_path
+                handle_id = "composed_scene"
+            else:
+                model_path = self._model_path_for_instance(instance_id)
+                build_model_for_handle(
+                    self.base_model_path,
+                    model_path,
+                    handle,
+                    prism_mount_pos=prism_mount_pos,
+                    prism_mount_quat=prism_mount_quat,
+                )
+
             sim = self._create_sim(instance_id, model_path, preset)
             instance = PrismInstance(
                 instance_id=instance_id,
@@ -191,6 +209,8 @@ class PrismRuntimeManager:
             }
 
     def swap_handle(self, instance_id: str, handle_id: str) -> dict:
+        if self.is_composed_mode():
+            raise ValueError("Handle swapping is disabled in composed-scene mode")
         with self._lock:
             if handle_id not in self.handle_catalog:
                 raise ValueError(f"Unknown handle_id: {handle_id}")
@@ -247,6 +267,8 @@ class PrismRuntimeManager:
             viewer.sync()
 
     def available_handles(self) -> list[dict]:
+        if self.is_composed_mode():
+            return []
         output = []
         for handle in self.handle_catalog.values():
             output.append(
@@ -323,6 +345,8 @@ class PrismRuntimeManager:
                 "running": bool(self._running),
                 "control_hz": float(self.control_hz),
                 "uptime_s": float(time.time() - self._created_at_s),
+                "composed_mode": self.is_composed_mode(),
+                "composed_model_path": str(self.composed_model_path) if self.composed_model_path else "",
                 "instance_count": len(self._instances),
                 "instance_ids": sorted(self._instances.keys()),
             }

--- a/prism_twin/simulation/instance_manager.py
+++ b/prism_twin/simulation/instance_manager.py
@@ -184,7 +184,9 @@ class PrismRuntimeManager:
     def get_status(self, instance_id: str) -> dict:
         with self._lock:
             inst = self.get_instance(instance_id)
-            return inst.sim.get_telemetry()
+            payload = inst.sim.get_telemetry()
+            payload["running"] = bool(self._running)
+            return payload
 
     def get_config(self, instance_id: str) -> dict:
         with self._lock:
@@ -249,6 +251,8 @@ class PrismRuntimeManager:
         with self._lock:
             inst = self.get_instance(instance_id)
             inst.sim.set_state(float(position_deg), float(vel_rad_s))
+            if not self._running:
+                inst.sim.step_control_tick()
             return {
                 "instance_id": instance_id,
                 "target_kind": "sim",
@@ -294,12 +298,7 @@ class PrismRuntimeManager:
 
         with self._lock:
             inst = self.get_instance(instance_id)
-            telem = inst.sim.get_telemetry()
-
-            sim = self._create_sim(instance_id, inst.model_path, preset_name)
-            sim.set_state(telem["pos_deg"], telem["vel_rad_s"])
-
-            inst.sim = sim
+            inst.sim.set_preset(preset_name)
             inst.preset = preset_name
 
             return {

--- a/prism_twin/simulation/run_sim.py
+++ b/prism_twin/simulation/run_sim.py
@@ -58,6 +58,22 @@ class PrismSim:
         self.joint_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, 'prism_joint')
         self.actuator_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, 'prism_motor')
 
+    def set_preset(self, preset_name: str) -> None:
+        preset_key = str(preset_name).upper()
+        if preset_key not in PRESETS:
+            raise ValueError(f"Unknown preset: {preset_key}")
+
+        self.physics = PrismPhysics(PRESETS[preset_key])
+        self.controller = FirmwareFaithfulTorqueController(
+            PRESETS[preset_key],
+            runtime=ControllerRuntimeConfig(control_hz=self.control_hz),
+        )
+        self.preset_name = preset_key
+        self._actuator_state_nm = 0.0
+        self._sensor_pos_delay = DelayLine(self.sensor_cfg.delay_s, self.control_dt)
+        self._sensor_vel_delay = DelayLine(self.sensor_cfg.delay_s, self.control_dt)
+        self._torque_command_delay = DelayLine(self.actuator_cfg.command_delay_s, self.control_dt)
+
     def get_telemetry(self):
         """
         Firmware-compatible status payload keys.

--- a/prism_twin/simulation/sim_helper_ui.html
+++ b/prism_twin/simulation/sim_helper_ui.html
@@ -1,74 +1,148 @@
-<!doctype html>
-<html lang="en">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>PRISM Twin Helper UI</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PRISM Sim Controller (Hardware-Style)</title>
   <style>
-    body { font-family: Segoe UI, Arial, sans-serif; margin: 16px; background: #f8f9fb; color: #111; }
-    .row { display: flex; gap: 12px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
-    .card { background: #fff; border: 1px solid #dfe3eb; border-radius: 8px; padding: 12px; max-width: 860px; }
-    .badge { display: inline-block; padding: 4px 8px; border-radius: 999px; font-weight: 600; font-size: 12px; }
-    .sim { background: #e8f3ff; color: #1155cc; border: 1px solid #bfd9ff; }
-    label { font-size: 13px; color: #444; }
-    select, input, button { padding: 6px 8px; border: 1px solid #ccd2de; border-radius: 6px; }
-    .telem { font-family: Consolas, monospace; background: #0d1117; color: #c9d1d9; border-radius: 8px; padding: 10px; min-width: 420px; white-space: pre; }
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font:13px/1.4 -apple-system,sans-serif;background:#fff;color:#000;padding:20px}
+    .container{max-width:980px;margin:0 auto}
+    h1{font-size:18px;font-weight:600;margin-bottom:6px;letter-spacing:-0.02em}
+    .subtitle{font-size:12px;color:#666;margin-bottom:14px}
+    .badge{display:inline-block;padding:3px 8px;border:1px solid #000;font-size:11px;font-weight:600;margin-right:6px}
+    .metrics{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:#d0d0d0;border:1px solid #d0d0d0;margin-bottom:20px}
+    .metric{background:#fff;padding:12px}
+    .metric-label{font-size:11px;color:#666;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:4px}
+    .metric-value{font:22px 'Courier New',monospace;font-weight:600;margin-bottom:2px;min-width:5.5ch;text-align:right}
+    .metric-spark{height:30px;width:100%;display:block}
+    .controls{border-top:1px solid #d0d0d0;padding-top:16px;margin-bottom:20px}
+    .btn-group{display:inline-block;margin-right:16px;margin-bottom:10px;vertical-align:top}
+    .btn-label{font-size:11px;color:#666;margin-bottom:4px;display:block}
+    button{font:12px -apple-system,sans-serif;padding:6px 12px;background:#000;color:#fff;border:none;cursor:pointer;margin-right:4px}
+    button:hover{background:#333}
+    button.stop{background:#c00}
+    button.stop:hover{background:#e00}
+    button:disabled{background:#999;cursor:not-allowed}
+    .select{font:12px -apple-system,sans-serif;padding:6px;background:#fff;border:1px solid #d0d0d0;margin-right:4px}
+    .config{border-top:1px solid #d0d0d0;padding-top:16px}
+    .config-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin-bottom:12px}
+    .config-label{font-size:11px;color:#666;margin-bottom:3px;display:block}
+    .config-input{font:13px 'Courier New',monospace;width:100%;padding:4px 6px;border:1px solid #d0d0d0;background:#fff}
+    .config-input:focus{outline:2px solid #000;outline-offset:-2px}
+    .sim-only{background:#f7f9ff;padding:10px;border:1px solid #dbe4ff;margin-bottom:16px}
+    .note{font-size:11px;color:#666;margin-top:6px}
+    .warn{color:#a35a00}
+    .mono{font-family:'Courier New',monospace}
   </style>
 </head>
 <body>
-  <div class="row">
-    <span class="badge sim" id="simBadge">SIM TARGET: prism_01</span>
-  </div>
-
-  <div class="card">
-    <div class="row">
-      <label>Instance</label>
-      <select id="instanceSelect"></select>
-      <button id="createInstance">Create prism_02</button>
+  <div class="container">
+    <h1>PRISM Sim Haptic Controller</h1>
+    <div class="subtitle">
+      <span class="badge" id="targetBadge">SIM TARGET: prism_01</span>
+      <span class="badge">HARDWARE-STYLE</span>
+      <span id="statusNote">Loading...</span>
     </div>
 
-    <div class="row">
-      <label>Handle</label>
-      <select id="handleSelect"></select>
-      <button id="applyHandle">Apply Handle</button>
+    <div class="metrics">
+      <div class="metric"><div class="metric-label">Position (deg)</div><div class="metric-value" id="pos">--</div><canvas class="metric-spark" id="sp"></canvas></div>
+      <div class="metric"><div class="metric-label">Velocity (rad/s)</div><div class="metric-value" id="vel">--</div><canvas class="metric-spark" id="sv"></canvas></div>
+      <div class="metric"><div class="metric-label">Torque (Nm)</div><div class="metric-value" id="tor">--</div><canvas class="metric-spark" id="st"></canvas></div>
     </div>
 
-    <div class="row">
-      <label>Preset</label>
-      <select id="presetSelect"></select>
-      <button id="applyPreset">Apply Preset</button>
+    <div class="sim-only">
+      <div class="btn-group">
+        <span class="btn-label">Instance Selector (Sim-only)</span>
+        <select id="instanceSelect" class="select"></select>
+        <button id="createInstance">Create prism_02</button>
+      </div>
+      <div class="btn-group">
+        <span class="btn-label">Viewer Target Select / Switch (Sim-only)</span>
+        <button id="switchViewer">Switch Viewer to Selected</button>
+      </div>
+      <div class="btn-group">
+        <span class="btn-label">Handle Selector + Swap (Sim-only)</span>
+        <select id="handleSelect" class="select"></select>
+        <button id="applyHandle">Apply Handle</button>
+      </div>
+      <div class="btn-group">
+        <span class="btn-label">Manual Position Drag Slider (Sim-only)</span>
+        <input id="manualPos" type="range" min="-180" max="180" value="0" step="0.5" style="width:220px;vertical-align:middle">
+        <span class="mono" id="manualPosValue">0.0</span>
+        <button id="applyPos">Apply</button>
+      </div>
+      <div class="btn-group">
+        <span class="btn-label">Scene / Debug Controls (Sim-only)</span>
+        <button id="worldFrameBtn" disabled>World Frame (startup-only)</button>
+        <button id="modelTriadBtn" disabled>Model Triad (startup-only)</button>
+      </div>
+      <div class="note">Scene/debug toggles are currently startup args on the server; runtime API wiring is not implemented yet.</div>
     </div>
 
-    <div class="row">
-      <label>Manual Position (deg)</label>
-      <input id="manualPos" type="range" min="-180" max="180" value="0" step="0.5" style="width: 320px;" />
-      <span id="manualPosValue">0.0</span>
-      <button id="applyPos">Apply</button>
+    <div class="controls">
+      <div class="btn-group"><span class="btn-label">System (Shared)</span><button id="startBtn">Resume</button><button class="stop" id="stopBtn">Pause</button></div>
+      <div class="btn-group"><span class="btn-label">Load Preset Intent (Shared)</span><select id="presetLoad" class="select"></select><button id="applyPresetIntent">Apply Preset</button></div>
+      <div class="btn-group"><span class="btn-label">Runtime Step (Sim helper)</span><button id="stepBtn">Step 10</button></div>
     </div>
 
-    <div class="row">
-      <button id="pauseBtn">Pause</button>
-      <button id="resumeBtn">Resume</button>
-      <button id="stepBtn">Step 10</button>
+    <div class="config">
+      <div class="config-grid">
+        <div><label class="config-label">Viscous (Nm·s/rad)</label><input class="config-input" type="number" id="viscous" step="0.01"></div>
+        <div><label class="config-label">Coulomb (Nm)</label><input class="config-input" type="number" id="coulomb" step="0.01"></div>
+        <div><label class="config-label">Wall Stiff (Nm/turn)</label><input class="config-input" type="number" id="stiffness" step="0.1"></div>
+        <div><label class="config-label">Wall Damp (Nm·s/turn)</label><input class="config-input" type="number" id="damping" step="0.01"></div>
+        <div><label class="config-label">Travel (deg)</label><input class="config-input" type="number" id="travel" step="1"></div>
+        <div><label class="config-label">Torque Limit (Nm)</label><input class="config-input" type="number" id="torque_limit" step="0.1"></div>
+        <div><label class="config-label">Smoothing (ε)</label><input class="config-input" type="number" id="smoothing" step="0.0001"></div>
+      </div>
+      <button id="applyConfigBtn" disabled>Apply Current Config Fields (planned)</button>
+      <div class="note warn">Planned: POST config endpoint parity on sim API is not yet implemented, so this section is read-only for now.</div>
     </div>
-  </div>
 
-  <div class="row" style="margin-top: 12px;">
-    <div class="telem" id="telem">loading...</div>
+    <div class="config" style="margin-top:20px">
+      <h2 style="font-size:14px;margin-bottom:12px">Manage Presets (Shared)</h2>
+      <div style="margin-bottom:12px">
+        <label class="config-label">Select Preset to Edit</label>
+        <select class="config-input" id="presetSelect" style="max-width:220px"></select>
+      </div>
+      <div class="config-grid">
+        <div><label class="config-label">Name</label><input class="config-input" type="text" id="pname" maxlength="30"></div>
+        <div><label class="config-label">Viscous</label><input class="config-input" type="number" id="pviscous" step="0.01"></div>
+        <div><label class="config-label">Coulomb</label><input class="config-input" type="number" id="pcoulomb" step="0.01"></div>
+        <div><label class="config-label">Wall Stiff</label><input class="config-input" type="number" id="pstiffness" step="0.1"></div>
+        <div><label class="config-label">Wall Damp</label><input class="config-input" type="number" id="pdamping" step="0.01"></div>
+        <div><label class="config-label">Travel</label><input class="config-input" type="number" id="ptravel" step="1"></div>
+        <div><label class="config-label">Torque Limit</label><input class="config-input" type="number" id="ptorque" step="0.1"></div>
+        <div><label class="config-label">Smoothing</label><input class="config-input" type="number" id="psmoothing" step="0.0001"></div>
+      </div>
+      <div style="margin-top:12px">
+        <button id="savePresetBtn" disabled>Save Preset Changes (planned)</button>
+        <button id="saveCurrentPresetBtn" disabled style="margin-left:8px">Save Current Config to Preset (planned)</button>
+      </div>
+      <div class="note warn">Planned: preset editing endpoints are not yet implemented on sim API. Preset load intent is wired via Apply Preset.</div>
+    </div>
   </div>
 
   <script>
+    const statusEls = [document.getElementById('pos'), document.getElementById('vel'), document.getElementById('tor')];
+    const sparkEls = [document.getElementById('sp'), document.getElementById('sv'), document.getElementById('st')];
+    const sparkData = [[], [], []];
+    const sparkMax = 60;
+
     const instanceSelect = document.getElementById('instanceSelect');
     const handleSelect = document.getElementById('handleSelect');
+    const presetLoad = document.getElementById('presetLoad');
     const presetSelect = document.getElementById('presetSelect');
-    const simBadge = document.getElementById('simBadge');
-    const telem = document.getElementById('telem');
     const manualPos = document.getElementById('manualPos');
     const manualPosValue = document.getElementById('manualPosValue');
+    const targetBadge = document.getElementById('targetBadge');
+    const statusNote = document.getElementById('statusNote');
+
     let dragActive = false;
     let dragTimer = null;
-    let presetDirty = false;
-    let manualOverrideUntil = 0;
+    let dragLastPosDeg = 0.0;
+    let dragLastTsMs = 0.0;
 
     function activeInstance() {
       return instanceSelect.value || 'prism_01';
@@ -83,59 +157,175 @@
       return await r.json();
     }
 
+    function drawSpark(canvas, values) {
+      const width = canvas.width = canvas.offsetWidth * 2;
+      const height = canvas.height = canvas.offsetHeight * 2;
+      const context = canvas.getContext('2d');
+      context.clearRect(0, 0, width, height);
+      if (values.length < 2) return;
+      const low = Math.min(...values);
+      const high = Math.max(...values);
+      const range = (high - low) || 1;
+      context.strokeStyle = '#000';
+      context.lineWidth = 2;
+      context.beginPath();
+      values.forEach((value, idx) => {
+        const x = (idx / (values.length - 1)) * width;
+        const y = height - ((value - low) / range) * height;
+        if (idx === 0) context.moveTo(x, y); else context.lineTo(x, y);
+      });
+      context.stroke();
+    }
+
+    function setConfigFromStatus(status) {
+      const closedPos = Number(status.closed_pos || 0);
+      const openPos = Number(status.open_pos || 0);
+      document.getElementById('viscous').value = Number(status.viscous || 0).toFixed(3);
+      document.getElementById('coulomb').value = Number(status.coulomb || 0).toFixed(3);
+      document.getElementById('stiffness').value = Number(status.wall_stiffness || 0).toFixed(2);
+      document.getElementById('damping').value = Number(status.wall_damping || 0).toFixed(3);
+      document.getElementById('travel').value = (openPos - closedPos).toFixed(1);
+      document.getElementById('torque_limit').value = Number(status.torque_limit || 0).toFixed(2);
+      document.getElementById('smoothing').value = Number(status.smoothing || 0).toFixed(6);
+    }
+
+    function setPresetEditorFromPreset(name) {
+      document.getElementById('pname').value = name;
+      document.getElementById('pviscous').value = document.getElementById('viscous').value;
+      document.getElementById('pcoulomb').value = document.getElementById('coulomb').value;
+      document.getElementById('pstiffness').value = document.getElementById('stiffness').value;
+      document.getElementById('pdamping').value = document.getElementById('damping').value;
+      document.getElementById('ptravel').value = document.getElementById('travel').value;
+      document.getElementById('ptorque').value = document.getElementById('torque_limit').value;
+      document.getElementById('psmoothing').value = document.getElementById('smoothing').value;
+    }
+
     async function refreshInstances() {
       const data = await api('/api/v1/instances');
       const prev = activeInstance();
       instanceSelect.innerHTML = '';
       for (const inst of data.instances || []) {
-        const opt = document.createElement('option');
-        opt.value = inst.instance_id;
-        opt.textContent = `${inst.instance_id} (${inst.handle_id})`;
-        instanceSelect.appendChild(opt);
+        const option = document.createElement('option');
+        option.value = inst.instance_id;
+        option.textContent = `${inst.instance_id} (${inst.handle_id})`;
+        instanceSelect.appendChild(option);
       }
       if ([...instanceSelect.options].some(o => o.value === prev)) {
         instanceSelect.value = prev;
       }
-      simBadge.textContent = `SIM TARGET: ${activeInstance()}`;
+      targetBadge.textContent = `SIM TARGET: ${activeInstance()}`;
     }
 
     async function refreshHandles() {
       const data = await api('/api/v1/handles');
       handleSelect.innerHTML = '';
       for (const h of data.handles || []) {
-        const opt = document.createElement('option');
-        opt.value = h.handle_id;
-        opt.textContent = `${h.handle_id} [${h.units}]`;
-        handleSelect.appendChild(opt);
+        const option = document.createElement('option');
+        option.value = h.handle_id;
+        option.textContent = `${h.handle_id} [${h.units}]`;
+        handleSelect.appendChild(option);
       }
     }
 
     async function refreshPresets() {
       const data = await api('/api/v1/presets');
+      presetLoad.innerHTML = '';
       presetSelect.innerHTML = '';
-      for (const p of data.presets || []) {
-        const opt = document.createElement('option');
-        opt.value = p;
-        opt.textContent = p;
-        presetSelect.appendChild(opt);
+      for (const name of data.presets || []) {
+        const a = document.createElement('option');
+        a.value = name;
+        a.textContent = name;
+        presetLoad.appendChild(a);
+        presetSelect.appendChild(a.cloneNode(true));
       }
+      setPresetEditorFromPreset(presetSelect.value || 'UNKNOWN');
+    }
+
+    async function refreshConfig() {
+      const data = await api(`/api/v1/config?instance_id=${encodeURIComponent(activeInstance())}`);
+      setConfigFromStatus(data);
+      setPresetEditorFromPreset(presetSelect.value || data.preset || 'UNKNOWN');
     }
 
     async function refreshTelemetry() {
-      const id = encodeURIComponent(activeInstance());
-      const data = await api(`/api/v1/status?instance_id=${id}`);
-      simBadge.textContent = `SIM TARGET: ${data.target_id || activeInstance()}`;
-      const canSyncPreset = !presetDirty && document.activeElement !== presetSelect;
-      if (canSyncPreset && data.active_preset && [...presetSelect.options].some(o => o.value === data.active_preset)) {
-        presetSelect.value = data.active_preset;
+      const data = await api(`/api/v1/status?instance_id=${encodeURIComponent(activeInstance())}`);
+      const values = [Number(data.pos_deg || 0), Number(data.vel_rad_s || 0), Number(data.torque_nm || 0)];
+      values.forEach((value, idx) => {
+        statusEls[idx].textContent = idx === 2 ? value.toFixed(3) : value.toFixed(2);
+        sparkData[idx].push(value);
+        if (sparkData[idx].length > sparkMax) sparkData[idx].shift();
+        drawSpark(sparkEls[idx], sparkData[idx]);
+      });
+
+      if (!dragActive) {
+        manualPos.value = values[0];
+        manualPosValue.textContent = values[0].toFixed(1);
       }
-      telem.textContent = JSON.stringify(data, null, 2);
-      const canSyncManualPos = !dragActive && document.activeElement !== manualPos && Date.now() > manualOverrideUntil;
-      if (canSyncManualPos) {
-        manualPosValue.textContent = Number(data.pos_deg || 0).toFixed(1);
-        manualPos.value = Number(data.pos_deg || 0);
+      const runState = (typeof data.running === 'boolean') ? (data.running ? 'running' : 'paused') : 'unknown';
+      statusNote.textContent = `status=${data.status} ${runState} preset=${data.active_preset}`;
+      targetBadge.textContent = `SIM TARGET: ${data.target_id || activeInstance()}`;
+    }
+
+    async function trySwitchViewer(instanceId) {
+      try {
+        await api('/api/v1/viewer/select', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ instance_id: instanceId, target_kind: 'sim', target_id: instanceId })
+        });
+        return true;
+      } catch {
+        return false;
       }
     }
+
+    function estimateDragVelRadS() {
+      const nowMs = performance.now();
+      const currentDeg = Number(manualPos.value);
+      if (dragLastTsMs <= 0) {
+        dragLastTsMs = nowMs;
+        dragLastPosDeg = currentDeg;
+        return 0.0;
+      }
+      const dtS = (nowMs - dragLastTsMs) / 1000.0;
+      if (dtS <= 1e-4) {
+        return 0.0;
+      }
+      const degPerS = (currentDeg - dragLastPosDeg) / dtS;
+      dragLastTsMs = nowMs;
+      dragLastPosDeg = currentDeg;
+      const radPerS = degPerS * (Math.PI / 180.0);
+      return Math.max(-20.0, Math.min(20.0, radPerS));
+    }
+
+    async function sendPosition(velRadS = 0.0) {
+      await api('/api/v1/interaction/set_position', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instance_id: activeInstance(), position_deg: Number(manualPos.value), vel_rad_s: Number(velRadS) })
+      });
+    }
+
+    document.getElementById('startBtn').onclick = async () => {
+      await api('/api/v1/control', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'resume' }) });
+    };
+    document.getElementById('stopBtn').onclick = async () => {
+      await api('/api/v1/control', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'pause' }) });
+    };
+    document.getElementById('stepBtn').onclick = async () => {
+      await api('/api/v1/control', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'step', ticks: 10 }) });
+      await refreshTelemetry();
+    };
+
+    document.getElementById('applyPresetIntent').onclick = async () => {
+      await api('/api/v1/preset/select', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instance_id: activeInstance(), preset: presetLoad.value })
+      });
+      await refreshConfig();
+      await refreshTelemetry();
+    };
 
     document.getElementById('createInstance').onclick = async () => {
       await api('/api/v1/instances', {
@@ -144,6 +334,17 @@
         body: JSON.stringify({ instance_id: 'prism_02' })
       });
       await refreshInstances();
+      if ([...instanceSelect.options].some(o => o.value === 'prism_02')) {
+        instanceSelect.value = 'prism_02';
+      }
+      await trySwitchViewer(activeInstance());
+      await refreshConfig();
+      await refreshTelemetry();
+    };
+
+    document.getElementById('switchViewer').onclick = async () => {
+      const ok = await trySwitchViewer(activeInstance());
+      statusNote.textContent = ok ? `viewer switched to ${activeInstance()}` : 'viewer switch unavailable (server not in --with-viewer mode)';
     };
 
     document.getElementById('applyHandle').onclick = async () => {
@@ -156,85 +357,54 @@
       await refreshTelemetry();
     };
 
-    document.getElementById('applyPreset').onclick = async () => {
-      await api('/api/v1/preset/select', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ instance_id: activeInstance(), preset: presetSelect.value })
-      });
-      presetDirty = false;
-      await refreshInstances();
-      await refreshTelemetry();
+    manualPos.oninput = () => {
+      manualPosValue.textContent = Number(manualPos.value).toFixed(1);
     };
-
-    presetSelect.onchange = () => {
-      presetDirty = true;
-    };
-
-    manualPos.oninput = () => { manualPosValue.textContent = Number(manualPos.value).toFixed(1); };
-
-    async function postDragPosition() {
-      if (!dragActive) return;
-      manualOverrideUntil = Date.now() + 1000;
-      await api('/api/v1/interaction/set_position', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ instance_id: activeInstance(), position_deg: Number(manualPos.value) })
-      });
-    }
 
     manualPos.addEventListener('pointerdown', () => {
       dragActive = true;
-      manualOverrideUntil = Date.now() + 1000;
+      dragLastPosDeg = Number(manualPos.value);
+      dragLastTsMs = performance.now();
       if (dragTimer) clearInterval(dragTimer);
-      dragTimer = setInterval(postDragPosition, 25);
-      postDragPosition();
-    });
-    manualPos.addEventListener('pointerup', () => {
-      dragActive = false;
-      if (dragTimer) clearInterval(dragTimer);
-      dragTimer = null;
-    });
-    manualPos.addEventListener('pointerleave', () => {
-      dragActive = false;
-      if (dragTimer) clearInterval(dragTimer);
-      dragTimer = null;
-    });
-    manualPos.addEventListener('pointercancel', () => {
-      dragActive = false;
-      if (dragTimer) clearInterval(dragTimer);
-      dragTimer = null;
+      dragTimer = setInterval(async () => {
+        try { await sendPosition(estimateDragVelRadS()); } catch {}
+      }, 30);
+      sendPosition(0.0);
     });
 
-    document.getElementById('applyPos').onclick = async () => {
-      manualOverrideUntil = Date.now() + 1000;
-      await api('/api/v1/interaction/set_position', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ instance_id: activeInstance(), position_deg: Number(manualPos.value) })
-      });
+    const stopDrag = () => {
+      dragActive = false;
+      if (dragTimer) clearInterval(dragTimer);
+      dragTimer = null;
+      dragLastTsMs = 0.0;
+    };
+    manualPos.addEventListener('pointerup', stopDrag);
+    manualPos.addEventListener('pointercancel', stopDrag);
+    manualPos.addEventListener('pointerleave', stopDrag);
+    document.getElementById('applyPos').onclick = async () => { await sendPosition(0.0); await refreshTelemetry(); };
+
+    instanceSelect.onchange = async () => {
+      await trySwitchViewer(activeInstance());
+      await refreshConfig();
       await refreshTelemetry();
     };
 
-    document.getElementById('pauseBtn').onclick = async () => {
-      await api('/api/v1/control', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'pause' }) });
-    };
-    document.getElementById('resumeBtn').onclick = async () => {
-      await api('/api/v1/control', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'resume' }) });
-    };
-    document.getElementById('stepBtn').onclick = async () => {
-      await api('/api/v1/control', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'step', ticks: 10 }) });
-      await refreshTelemetry();
-    };
-
-    instanceSelect.onchange = () => refreshTelemetry();
+    presetSelect.onchange = () => setPresetEditorFromPreset(presetSelect.value || 'UNKNOWN');
+    presetLoad.onchange = () => setPresetEditorFromPreset(presetLoad.value || 'UNKNOWN');
 
     (async () => {
-      await refreshHandles();
-      await refreshPresets();
-      await refreshInstances();
-      await refreshTelemetry();
-      setInterval(refreshTelemetry, 250);
+      try {
+        await refreshInstances();
+        await refreshHandles();
+        await refreshPresets();
+        await refreshConfig();
+        await refreshTelemetry();
+        setInterval(async () => {
+          try { await refreshTelemetry(); } catch {}
+        }, 150);
+      } catch (err) {
+        statusNote.textContent = String(err);
+      }
     })();
   </script>
 </body>

--- a/prism_twin/simulation/target_router.py
+++ b/prism_twin/simulation/target_router.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from instance_manager import PrismRuntimeManager
+
+
+@dataclass(frozen=True)
+class TargetRef:
+    target_kind: str
+    target_id: str
+
+
+class SimTargetAdapter:
+    def __init__(self, manager: PrismRuntimeManager):
+        self.manager = manager
+
+    def get_status(self, target_id: str) -> dict:
+        self.manager.ensure_instance(target_id)
+        return self.manager.get_status(target_id)
+
+    def get_config(self, target_id: str) -> dict:
+        self.manager.ensure_instance(target_id)
+        return self.manager.get_config(target_id)
+
+
+class RealTargetAdapter:
+    def get_status(self, target_id: str) -> dict:
+        raise NotImplementedError(f"Real target adapter not configured for target_id={target_id}")
+
+    def get_config(self, target_id: str) -> dict:
+        raise NotImplementedError(f"Real target adapter not configured for target_id={target_id}")
+
+
+class TargetRouter:
+    def __init__(self, sim_adapter: SimTargetAdapter, real_adapter: RealTargetAdapter):
+        self.sim_adapter = sim_adapter
+        self.real_adapter = real_adapter
+
+    @staticmethod
+    def _value(query: dict[str, list[str]], body: dict[str, Any], key: str) -> str | None:
+        if key in query and len(query[key]) > 0:
+            return str(query[key][0])
+        value = body.get(key)
+        if value is None:
+            return None
+        return str(value)
+
+    def resolve_target(self, query: dict[str, list[str]], body: dict[str, Any], default_target_id: str) -> TargetRef:
+        target_kind = (self._value(query, body, "target_kind") or "sim").strip().lower()
+        target_id = (
+            self._value(query, body, "target_id")
+            or self._value(query, body, "instance_id")
+            or default_target_id
+        )
+        return TargetRef(target_kind=target_kind, target_id=str(target_id))
+
+    def get_adapter(self, target_kind: str):
+        if target_kind == "sim":
+            return self.sim_adapter
+        if target_kind == "real":
+            return self.real_adapter
+        raise ValueError(f"Unsupported target_kind: {target_kind}")

--- a/prism_twin/simulation/target_router.py
+++ b/prism_twin/simulation/target_router.py
@@ -12,6 +12,10 @@ class TargetRef:
     target_id: str
 
 
+class TargetNotConfiguredError(RuntimeError):
+    pass
+
+
 class SimTargetAdapter:
     def __init__(self, manager: PrismRuntimeManager):
         self.manager = manager
@@ -27,10 +31,10 @@ class SimTargetAdapter:
 
 class RealTargetAdapter:
     def get_status(self, target_id: str) -> dict:
-        raise NotImplementedError(f"Real target adapter not configured for target_id={target_id}")
+        raise TargetNotConfiguredError(f"Real target adapter not configured for target_id={target_id}")
 
     def get_config(self, target_id: str) -> dict:
-        raise NotImplementedError(f"Real target adapter not configured for target_id={target_id}")
+        raise TargetNotConfiguredError(f"Real target adapter not configured for target_id={target_id}")
 
 
 class TargetRouter:

--- a/prism_twin/simulation/twin_rest_server.py
+++ b/prism_twin/simulation/twin_rest_server.py
@@ -21,6 +21,8 @@ class TwinApiHandler(BaseHTTPRequestHandler):
     request_count: int = 0
     session_bindings: dict[str, dict] = {}
     session_lock = threading.RLock()
+    session_ttl_s: float = 900.0
+    session_max_count: int = 64
 
     def _send_json(self, status: int, payload: dict) -> None:
         body = json.dumps(payload).encode("utf-8")
@@ -76,6 +78,37 @@ class TwinApiHandler(BaseHTTPRequestHandler):
             self.request_count += 1
             return self.request_count
 
+    def _prune_sessions(self) -> dict:
+        now_s = time.time()
+        with self.session_lock:
+            before = len(self.session_bindings)
+            expired_ids = [
+                sid
+                for sid, item in self.session_bindings.items()
+                if (now_s - float(item.get("last_seen_s", now_s))) > self.session_ttl_s
+            ]
+            for sid in expired_ids:
+                self.session_bindings.pop(sid, None)
+
+            evicted = 0
+            if len(self.session_bindings) > self.session_max_count:
+                ranked = sorted(
+                    self.session_bindings.items(),
+                    key=lambda kv: float(kv[1].get("last_seen_s", now_s)),
+                )
+                overflow = len(self.session_bindings) - self.session_max_count
+                for sid, _ in ranked[:overflow]:
+                    self.session_bindings.pop(sid, None)
+                    evicted += 1
+
+            after = len(self.session_bindings)
+        return {
+            "before": before,
+            "after": after,
+            "expired": len(expired_ids),
+            "evicted": evicted,
+        }
+
     def _runtime_payload(self, mgr: PrismRuntimeManager) -> dict:
         summary = mgr.runtime_summary()
         with self.session_lock:
@@ -94,6 +127,10 @@ class TwinApiHandler(BaseHTTPRequestHandler):
             "status": "ok",
             "uptime_s": float(time.time() - self.runtime_started_at_s),
             "requests": req_count,
+            "session_policy": {
+                "ttl_s": float(self.session_ttl_s),
+                "max_count": int(self.session_max_count),
+            },
             "manager": summary,
             "instances": mgr.list_instances(),
             "sessions": sessions,
@@ -101,6 +138,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         self._bump_request_count()
+        self._prune_sessions()
         mgr = self._manager()
         parsed = urlparse(self.path)
         query = parse_qs(parsed.query)
@@ -137,6 +175,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
 
             if parsed.path == "/api/v1/health":
                 runtime = mgr.runtime_summary()
+                session_stats = self._prune_sessions()
                 self._send_json(
                     200,
                     {
@@ -144,6 +183,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                         "uptime_s": float(time.time() - self.runtime_started_at_s),
                         "running": bool(runtime["running"]),
                         "instance_count": int(runtime["instance_count"]),
+                        "session_count": int(session_stats["after"]),
                     },
                 )
                 return
@@ -158,6 +198,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:
         self._bump_request_count()
+        self._prune_sessions()
         mgr = self._manager()
         parsed = urlparse(self.path)
         query = parse_qs(parsed.query)
@@ -218,6 +259,10 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                         "status": "ok",
                         "created_instance": bool(created),
                         "created_session": bool(created_session),
+                        "session_policy": {
+                            "ttl_s": float(self.session_ttl_s),
+                            "max_count": int(self.session_max_count),
+                        },
                         "session": {
                             "session_id": session_id,
                             "instance_id": instance.instance_id,
@@ -294,6 +339,18 @@ def main() -> int:
     parser.add_argument("--port", type=int, default=8081)
     parser.add_argument("--start-loop", action="store_true", help="Start background realtime stepping loop")
     parser.add_argument(
+        "--session-ttl-s",
+        type=float,
+        default=900.0,
+        help="Session inactivity TTL in seconds before automatic expiration.",
+    )
+    parser.add_argument(
+        "--session-max-count",
+        type=int,
+        default=64,
+        help="Maximum number of active sessions before LRU-style eviction by last_seen.",
+    )
+    parser.add_argument(
         "--with-viewer",
         action="store_true",
         help="Run native MuJoCo viewer attached to the same runtime used by the helper UI/API.",
@@ -322,6 +379,8 @@ def main() -> int:
     TwinApiHandler.runtime_started_at_s = time.time()
     TwinApiHandler.request_count = 0
     TwinApiHandler.session_bindings = {}
+    TwinApiHandler.session_ttl_s = max(1.0, float(args.session_ttl_s))
+    TwinApiHandler.session_max_count = max(1, int(args.session_max_count))
     server = ThreadingHTTPServer((args.host, args.port), TwinApiHandler)
     print(f"Twin REST server listening on http://{args.host}:{args.port}")
     try:

--- a/prism_twin/simulation/twin_rest_server.py
+++ b/prism_twin/simulation/twin_rest_server.py
@@ -13,7 +13,7 @@ import mujoco
 import mujoco.viewer
 
 from instance_manager import PrismRuntimeManager
-from target_router import RealTargetAdapter, SimTargetAdapter, TargetRouter
+from target_router import RealTargetAdapter, SimTargetAdapter, TargetNotConfiguredError, TargetRouter
 
 
 class TwinApiHandler(BaseHTTPRequestHandler):
@@ -150,6 +150,32 @@ class TwinApiHandler(BaseHTTPRequestHandler):
             "sessions": sessions,
         }
 
+    def _capabilities_payload(self, mgr: PrismRuntimeManager) -> dict:
+        composed_mode = bool(mgr.runtime_summary().get("composed_mode", False))
+        return {
+            "status": "ok",
+            "targets": {
+                "sim": {
+                    "configured": True,
+                    "shared_endpoints": ["status", "config"],
+                    "sim_only_endpoints": [
+                        "instances",
+                        "session_bind",
+                        "control",
+                        "handle_select",
+                        "preset_select",
+                        "interaction_set_position",
+                    ],
+                    "composed_mode": composed_mode,
+                },
+                "real": {
+                    "configured": False,
+                    "shared_endpoints": ["status", "config"],
+                    "sim_only_endpoints": [],
+                },
+            },
+        }
+
     def do_GET(self) -> None:
         self._bump_request_count()
         self._prune_sessions()
@@ -208,7 +234,13 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 self._send_json(200, self._runtime_payload(mgr))
                 return
 
+            if parsed.path == "/api/v1/targets/capabilities":
+                self._send_json(200, self._capabilities_payload(mgr))
+                return
+
             self._send_json(404, {"status": "error", "error": "not_found"})
+        except TargetNotConfiguredError as exc:
+            self._send_json(501, {"status": "error", "error": str(exc)})
         except Exception as exc:
             self._send_json(500, {"status": "error", "error": str(exc)})
 

--- a/prism_twin/simulation/twin_rest_server.py
+++ b/prism_twin/simulation/twin_rest_server.py
@@ -13,10 +13,12 @@ import mujoco
 import mujoco.viewer
 
 from instance_manager import PrismRuntimeManager
+from target_router import RealTargetAdapter, SimTargetAdapter, TargetRouter
 
 
 class TwinApiHandler(BaseHTTPRequestHandler):
     manager: PrismRuntimeManager | None = None
+    router: TargetRouter | None = None
     runtime_started_at_s: float = 0.0
     request_count: int = 0
     session_bindings: dict[str, dict] = {}
@@ -64,6 +66,18 @@ class TwinApiHandler(BaseHTTPRequestHandler):
         if self.manager is None:
             raise RuntimeError("Manager not initialized")
         return self.manager
+
+    def _router(self) -> TargetRouter:
+        if self.router is None:
+            raise RuntimeError("Target router not initialized")
+        return self.router
+
+    def _require_sim_target(self, query: dict, body: dict, default_instance_id: str = "prism_01") -> str:
+        router = self._router()
+        target = router.resolve_target(query, body, default_target_id=default_instance_id)
+        if target.target_kind != "sim":
+            raise ValueError("This endpoint is simulation-only. Use target_kind=sim.")
+        return target.target_id
 
     def _send_html(self, status: int, html_text: str) -> None:
         body = html_text.encode("utf-8")
@@ -150,15 +164,17 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 return
 
             if parsed.path == "/api/v1/status":
-                instance_id = self._instance_id(query, {})
-                mgr.ensure_instance(instance_id)
-                self._send_json(200, mgr.get_status(instance_id))
+                default_instance_id = self._instance_id(query, {})
+                target = self._router().resolve_target(query, {}, default_target_id=default_instance_id)
+                adapter = self._router().get_adapter(target.target_kind)
+                self._send_json(200, adapter.get_status(target.target_id))
                 return
 
             if parsed.path == "/api/v1/config":
-                instance_id = self._instance_id(query, {})
-                mgr.ensure_instance(instance_id)
-                self._send_json(200, mgr.get_config(instance_id))
+                default_instance_id = self._instance_id(query, {})
+                target = self._router().resolve_target(query, {}, default_target_id=default_instance_id)
+                adapter = self._router().get_adapter(target.target_kind)
+                self._send_json(200, adapter.get_config(target.target_id))
                 return
 
             if parsed.path == "/api/v1/instances":
@@ -206,7 +222,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
 
         try:
             if parsed.path == "/api/v1/instances":
-                instance_id = self._instance_id(query, body)
+                instance_id = self._require_sim_target(query, body, default_instance_id=self._instance_id(query, body))
                 handle_id = body.get("handle_id")
                 preset = body.get("preset")
                 instance, created = mgr.create_or_get_instance(instance_id=instance_id, handle_id=handle_id, preset=preset)
@@ -227,7 +243,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 return
 
             if parsed.path == "/api/v1/session/bind":
-                instance_id = self._instance_id(query, body)
+                instance_id = self._require_sim_target(query, body, default_instance_id=self._instance_id(query, body))
                 create_if_missing = bool(body.get("create_if_missing", True))
                 if create_if_missing:
                     instance, created = mgr.create_or_get_instance(instance_id=instance_id)
@@ -274,7 +290,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 return
 
             if parsed.path == "/api/v1/control":
-                instance_id = self._instance_id(query, body)
+                instance_id = self._require_sim_target(query, body, default_instance_id=self._instance_id(query, body))
                 mgr.ensure_instance(instance_id)
                 action = str(body.get("action", "step"))
                 ticks = int(body.get("ticks", 1))
@@ -296,7 +312,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 return
 
             if parsed.path == "/api/v1/handle/select":
-                instance_id = self._instance_id(query, body)
+                instance_id = self._require_sim_target(query, body, default_instance_id=self._instance_id(query, body))
                 handle_id = str(body.get("handle_id", ""))
                 if not handle_id:
                     self._send_json(400, {"status": "error", "error": "missing_handle_id"})
@@ -307,7 +323,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 return
 
             if parsed.path == "/api/v1/preset/select":
-                instance_id = self._instance_id(query, body)
+                instance_id = self._require_sim_target(query, body, default_instance_id=self._instance_id(query, body))
                 preset = str(body.get("preset", ""))
                 if not preset:
                     self._send_json(400, {"status": "error", "error": "missing_preset"})
@@ -318,7 +334,7 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 return
 
             if parsed.path == "/api/v1/interaction/set_position":
-                instance_id = self._instance_id(query, body)
+                instance_id = self._require_sim_target(query, body, default_instance_id=self._instance_id(query, body))
                 position_deg = float(body.get("position_deg", 0.0))
                 vel_rad_s = float(body.get("vel_rad_s", 0.0))
                 mgr.ensure_instance(instance_id)
@@ -382,6 +398,10 @@ def main() -> int:
         mgr.start(realtime=True)
 
     TwinApiHandler.manager = mgr
+    TwinApiHandler.router = TargetRouter(
+        sim_adapter=SimTargetAdapter(mgr),
+        real_adapter=RealTargetAdapter(),
+    )
     TwinApiHandler.runtime_started_at_s = time.time()
     TwinApiHandler.request_count = 0
     TwinApiHandler.session_bindings = {}

--- a/prism_twin/simulation/twin_rest_server.py
+++ b/prism_twin/simulation/twin_rest_server.py
@@ -25,6 +25,9 @@ class TwinApiHandler(BaseHTTPRequestHandler):
     session_lock = threading.RLock()
     session_ttl_s: float = 900.0
     session_max_count: int = 64
+    viewer_enabled: bool = False
+    viewer_instance_id: str = "prism_01"
+    viewer_switch_requested: bool = False
 
     def _send_json(self, status: int, payload: dict) -> None:
         body = json.dumps(payload).encode("utf-8")
@@ -374,6 +377,19 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 self._send_json(200, {"status": "ok", "result": result})
                 return
 
+            if parsed.path == "/api/v1/viewer/select":
+                cls = type(self)
+                if not cls.viewer_enabled:
+                    self._send_json(409, {"status": "error", "error": "viewer_not_enabled"})
+                    return
+                instance_id = self._require_sim_target(query, body, default_instance_id=self._instance_id(query, body))
+                mgr.ensure_instance(instance_id)
+                with self.session_lock:
+                    cls.viewer_instance_id = instance_id
+                    cls.viewer_switch_requested = True
+                self._send_json(200, {"status": "ok", "viewer_instance": instance_id})
+                return
+
             self._send_json(404, {"status": "error", "error": "not_found"})
         except ValueError as exc:
             self._send_json(400, {"status": "error", "error": str(exc)})
@@ -439,6 +455,9 @@ def main() -> int:
     TwinApiHandler.session_bindings = {}
     TwinApiHandler.session_ttl_s = max(1.0, float(args.session_ttl_s))
     TwinApiHandler.session_max_count = max(1, int(args.session_max_count))
+    TwinApiHandler.viewer_enabled = bool(args.with_viewer)
+    TwinApiHandler.viewer_instance_id = str(args.viewer_instance)
+    TwinApiHandler.viewer_switch_requested = False
     server = ThreadingHTTPServer((args.host, args.port), TwinApiHandler)
     mode = "composed" if composed_model_path else "standalone"
     print(f"Twin REST server listening on http://{args.host}:{args.port} (mode={mode})")
@@ -447,17 +466,31 @@ def main() -> int:
             server_thread = threading.Thread(target=server.serve_forever, daemon=True)
             server_thread.start()
 
-            mgr.ensure_instance(args.viewer_instance)
-            model, data = mgr.get_viewer_state(args.viewer_instance)
-            with mujoco.viewer.launch_passive(model, data) as viewer:
-                viewer.opt.geomgroup[4] = 1 if args.show_model_triad else 0
-                viewer.opt.sitegroup[4] = 1 if args.show_model_triad else 0
-                if args.show_world_frame:
-                    viewer.opt.frame = mujoco.mjtFrame.mjFRAME_WORLD
+            while True:
+                with TwinApiHandler.session_lock:
+                    current_view_instance = TwinApiHandler.viewer_instance_id
+                    TwinApiHandler.viewer_switch_requested = False
 
-                while viewer.is_running():
-                    mgr.sync_viewer(viewer)
-                    time.sleep(0.01)
+                mgr.ensure_instance(current_view_instance)
+                model, data = mgr.get_viewer_state(current_view_instance)
+                with mujoco.viewer.launch_passive(model, data) as viewer:
+                    viewer.opt.geomgroup[4] = 1 if args.show_model_triad else 0
+                    viewer.opt.sitegroup[4] = 1 if args.show_model_triad else 0
+                    if args.show_world_frame:
+                        viewer.opt.frame = mujoco.mjtFrame.mjFRAME_WORLD
+
+                    while viewer.is_running():
+                        mgr.sync_viewer(viewer)
+                        with TwinApiHandler.session_lock:
+                            requested_switch = bool(TwinApiHandler.viewer_switch_requested)
+                        if requested_switch:
+                            break
+                        time.sleep(0.01)
+
+                with TwinApiHandler.session_lock:
+                    requested_switch = bool(TwinApiHandler.viewer_switch_requested)
+                if not requested_switch:
+                    break
         else:
             server.serve_forever()
     finally:

--- a/prism_twin/simulation/twin_rest_server.py
+++ b/prism_twin/simulation/twin_rest_server.py
@@ -337,6 +337,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="PRISM twin REST server (instance-scoped simulation API)")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8081)
+    parser.add_argument(
+        "--composed-model",
+        default="",
+        help="Optional path to an existing composed MuJoCo model to attach PRISM runtime without model regeneration.",
+    )
     parser.add_argument("--start-loop", action="store_true", help="Start background realtime stepping loop")
     parser.add_argument(
         "--session-ttl-s",
@@ -369,7 +374,8 @@ def main() -> int:
     args = parser.parse_args()
 
     root_dir = Path(__file__).resolve().parents[1]
-    mgr = PrismRuntimeManager(root_dir=root_dir)
+    composed_model_path = Path(args.composed_model).resolve() if str(args.composed_model).strip() else None
+    mgr = PrismRuntimeManager(root_dir=root_dir, composed_model_path=composed_model_path)
     mgr.ensure_instance("prism_01")
     start_loop = args.start_loop or args.with_viewer
     if start_loop:
@@ -382,7 +388,8 @@ def main() -> int:
     TwinApiHandler.session_ttl_s = max(1.0, float(args.session_ttl_s))
     TwinApiHandler.session_max_count = max(1, int(args.session_max_count))
     server = ThreadingHTTPServer((args.host, args.port), TwinApiHandler)
-    print(f"Twin REST server listening on http://{args.host}:{args.port}")
+    mode = "composed" if composed_model_path else "standalone"
+    print(f"Twin REST server listening on http://{args.host}:{args.port} (mode={mode})")
     try:
         if args.with_viewer:
             server_thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/prism_twin/simulation/twin_rest_server.py
+++ b/prism_twin/simulation/twin_rest_server.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import threading
 import time
+import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -16,6 +17,10 @@ from instance_manager import PrismRuntimeManager
 
 class TwinApiHandler(BaseHTTPRequestHandler):
     manager: PrismRuntimeManager | None = None
+    runtime_started_at_s: float = 0.0
+    request_count: int = 0
+    session_bindings: dict[str, dict] = {}
+    session_lock = threading.RLock()
 
     def _send_json(self, status: int, payload: dict) -> None:
         body = json.dumps(payload).encode("utf-8")
@@ -37,7 +42,21 @@ class TwinApiHandler(BaseHTTPRequestHandler):
             return query["instance_id"][0]
         if "instance_id" in body:
             return str(body["instance_id"])
+        session_id = self._session_id(query, body)
+        if session_id:
+            with self.session_lock:
+                session = self.session_bindings.get(session_id)
+                if session is not None:
+                    session["last_seen_s"] = time.time()
+                    return str(session["instance_id"])
         return "prism_01"
+
+    def _session_id(self, query: dict, body: dict) -> str | None:
+        if "session_id" in query and len(query["session_id"]) > 0:
+            return str(query["session_id"][0])
+        if "session_id" in body and body["session_id"]:
+            return str(body["session_id"])
+        return None
 
     def _manager(self) -> PrismRuntimeManager:
         if self.manager is None:
@@ -52,7 +71,36 @@ class TwinApiHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _bump_request_count(self) -> int:
+        with self.session_lock:
+            self.request_count += 1
+            return self.request_count
+
+    def _runtime_payload(self, mgr: PrismRuntimeManager) -> dict:
+        summary = mgr.runtime_summary()
+        with self.session_lock:
+            sessions = [
+                {
+                    "session_id": sid,
+                    "instance_id": item["instance_id"],
+                    "client_id": item.get("client_id", ""),
+                    "created_at_s": float(item["created_at_s"]),
+                    "last_seen_s": float(item["last_seen_s"]),
+                }
+                for sid, item in self.session_bindings.items()
+            ]
+            req_count = int(self.request_count)
+        return {
+            "status": "ok",
+            "uptime_s": float(time.time() - self.runtime_started_at_s),
+            "requests": req_count,
+            "manager": summary,
+            "instances": mgr.list_instances(),
+            "sessions": sessions,
+        }
+
     def do_GET(self) -> None:
+        self._bump_request_count()
         mgr = self._manager()
         parsed = urlparse(self.path)
         query = parse_qs(parsed.query)
@@ -87,11 +135,29 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 self._send_json(200, {"presets": mgr.available_presets()})
                 return
 
+            if parsed.path == "/api/v1/health":
+                runtime = mgr.runtime_summary()
+                self._send_json(
+                    200,
+                    {
+                        "status": "ok",
+                        "uptime_s": float(time.time() - self.runtime_started_at_s),
+                        "running": bool(runtime["running"]),
+                        "instance_count": int(runtime["instance_count"]),
+                    },
+                )
+                return
+
+            if parsed.path == "/api/v1/runtime":
+                self._send_json(200, self._runtime_payload(mgr))
+                return
+
             self._send_json(404, {"status": "error", "error": "not_found"})
         except Exception as exc:
             self._send_json(500, {"status": "error", "error": str(exc)})
 
     def do_POST(self) -> None:
+        self._bump_request_count()
         mgr = self._manager()
         parsed = urlparse(self.path)
         query = parse_qs(parsed.query)
@@ -102,18 +168,59 @@ class TwinApiHandler(BaseHTTPRequestHandler):
                 instance_id = self._instance_id(query, body)
                 handle_id = body.get("handle_id")
                 preset = body.get("preset")
-                if instance_id in {item["instance_id"] for item in mgr.list_instances()}:
-                    self._send_json(200, {"status": "ok", "instance": mgr.get_config(instance_id)})
-                    return
-                instance = mgr.create_instance(instance_id=instance_id, handle_id=handle_id, preset=preset)
+                instance, created = mgr.create_or_get_instance(instance_id=instance_id, handle_id=handle_id, preset=preset)
                 self._send_json(
-                    201,
+                    201 if created else 200,
                     {
                         "status": "ok",
+                        "created": bool(created),
                         "instance": {
                             "instance_id": instance.instance_id,
                             "handle_id": instance.handle_id,
                             "preset": instance.preset,
+                            "target_kind": "sim",
+                            "target_id": instance.instance_id,
+                        },
+                    },
+                )
+                return
+
+            if parsed.path == "/api/v1/session/bind":
+                instance_id = self._instance_id(query, body)
+                create_if_missing = bool(body.get("create_if_missing", True))
+                if create_if_missing:
+                    instance, created = mgr.create_or_get_instance(instance_id=instance_id)
+                else:
+                    instance = mgr.get_instance(instance_id)
+                    created = False
+
+                session_id = self._session_id(query, body) or str(uuid.uuid4())
+                now_s = time.time()
+                client_id = str(body.get("client_id", ""))
+                with self.session_lock:
+                    existing = self.session_bindings.get(session_id)
+                    created_session = existing is None
+                    if existing is None:
+                        self.session_bindings[session_id] = {
+                            "instance_id": instance.instance_id,
+                            "client_id": client_id,
+                            "created_at_s": now_s,
+                            "last_seen_s": now_s,
+                        }
+                    else:
+                        existing["instance_id"] = instance.instance_id
+                        existing["client_id"] = client_id or existing.get("client_id", "")
+                        existing["last_seen_s"] = now_s
+
+                self._send_json(
+                    200,
+                    {
+                        "status": "ok",
+                        "created_instance": bool(created),
+                        "created_session": bool(created_session),
+                        "session": {
+                            "session_id": session_id,
+                            "instance_id": instance.instance_id,
                             "target_kind": "sim",
                             "target_id": instance.instance_id,
                         },
@@ -212,6 +319,9 @@ def main() -> int:
         mgr.start(realtime=True)
 
     TwinApiHandler.manager = mgr
+    TwinApiHandler.runtime_started_at_s = time.time()
+    TwinApiHandler.request_count = 0
+    TwinApiHandler.session_bindings = {}
     server = ThreadingHTTPServer((args.host, args.port), TwinApiHandler)
     print(f"Twin REST server listening on http://{args.host}:{args.port}")
     try:


### PR DESCRIPTION
## Summary
- make pause/resume explicit in sim helper UI controls
- send velocity-aware manual drag updates so heavy friction torque is observable during interaction
- surface runtime running/paused state in status payload and UI status line
- trigger one control tick on manual set-position while paused for immediate torque feedback
- restore and verify GitHub automation path (`gh` install/auth), and keep multi-instance architecture issue draft in repo

## Validation
- verified non-zero torque after paused manual position update with velocity injection
- verified UI serves explicit `Resume` / `Pause` controls
- verified issue creation automation works and published #13

## Related
- Closes #13